### PR TITLE
feat: login page design tweaks

### DIFF
--- a/ui/components/LoginComponent.tsx
+++ b/ui/components/LoginComponent.tsx
@@ -27,7 +27,6 @@ export const LoginComponent = ({ apiUrl }: LoginComponentProps) => {
       ) as HTMLFormElement;
 
       const formData = new FormData(form);
-      console.log(formData);
 
       const res = await fetch(apiUrl || `/api/login`, {
         method: "post",
@@ -55,13 +54,13 @@ export const LoginComponent = ({ apiUrl }: LoginComponentProps) => {
   return (
     <>
       <style>{`body {background: #f1f5f9;}`}</style>
-      <div className="lg:h-screen flex flex-col lg:flex-row divide-y lg:divide-y-0 divide-x">
-        <div className="order-0 lg:order-1 flex-1 flex flex-col items-center justify-center px-10">
+      <div className="lg:h-screen flex flex-col lg:flex-row bg-gradient-to-bl from-brand-blue to-brand-blue-dark lg:overflow-hidden">
+        <div className="order-0 lg:order-1 flex-1 flex flex-col items-center justify-center px-10 py-8 lg:py-0">
           <div className="w-full lg:max-w-sm" id="password-form">
             <form
               data-testid="form"
               onSubmit={onSubmit}
-              className="my-8 w-full flex flex-col"
+              className="w-full flex flex-col space-y-4"
             >
               <input
                 name="password"
@@ -69,10 +68,17 @@ export const LoginComponent = ({ apiUrl }: LoginComponentProps) => {
                 id="password"
                 placeholder="Enter password"
                 required
-                className={`border py-2 px-3 ${error ? "border-red-500" : ""}`}
+                className={`rounded border border-transparent shadow-lg py-2 px-3 ${
+                  error
+                    ? "ring ring-red-400 ring-opacity-50 border-red-600"
+                    : ""
+                }`}
               />
               {!!error && (
-                <div className="text-red-500" data-testid="error">
+                <div
+                  className="text-red-500 bg-red-100 px-2 py-1 text-sm rounded"
+                  data-testid="error"
+                >
                   {error}
                 </div>
               )}
@@ -80,22 +86,27 @@ export const LoginComponent = ({ apiUrl }: LoginComponentProps) => {
               <button
                 type="submit"
                 disabled={isBusy}
-                className="font-semibold w-full text-sm py-3 uppercase tracking-wide mt-3 bg-gray-900 text-white"
+                className="font-semibold w-full text-sm py-3 uppercase tracking-wide bg-gray-900 text-white"
               >
                 {isBusy ? "Logging in..." : "Login"}
               </button>
             </form>
           </div>
         </div>
-        <div className="lg:w-1/2 flex-shrink-0 bg-white divide-y">
+        <div className="lg:w-1/2 flex-shrink-0 bg-white shadow-xl divide-y overflow-auto">
           <div className="p-4 lg:p-8">
             <div className="block w-16 mx-auto">
               <Image src={UNDPLogo} alt="UNDP Logo" />
             </div>
 
-            <h1 className="font-medium text-2xl text-center mt-2">
-              Digital Development Compass
-            </h1>
+            <div className="flex items-center justify-center space-x-2 mt-2 mx-auto">
+              <h1 className="font-medium text-2xl text-center">
+                Digital Development Compass
+              </h1>
+              <span className="inline-flex items-center px-[10px] py-[2px] rounded-full font-semibold bg-blue-100 text-blue-800 uppercase text-[10px] lg:text-xs tracking-widest">
+                Beta
+              </span>
+            </div>
 
             <p className="text-gray-600 text-left mt-4">
               The Digital Development Compass is a new tool that aggregates

--- a/ui/components/LoginComponent.tsx
+++ b/ui/components/LoginComponent.tsx
@@ -1,15 +1,14 @@
-import Image from 'next/image';
-import React, { useState } from 'react';
+import Image from "next/image";
+import React, { useState } from "react";
+import UNDPLogo from "../public/undp-logo.svg";
 
 export interface LoginComponentProps {
   apiUrl?: string;
 }
 
-export const LoginComponent = ({
-  apiUrl,
-}: LoginComponentProps) => {
+export const LoginComponent = ({ apiUrl }: LoginComponentProps) => {
   const [isBusy, setBusy] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState("");
 
   const onSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -20,21 +19,21 @@ export const LoginComponent = ({
     }
 
     setBusy(true);
-    setError('');
+    setError("");
 
     try {
       const form = document.querySelector(
-        '#password-form form',
+        "#password-form form"
       ) as HTMLFormElement;
 
       const formData = new FormData(form);
-      console.log(formData)
+      console.log(formData);
 
       const res = await fetch(apiUrl || `/api/login`, {
-        method: 'post',
-        credentials: 'include',
-        body: JSON.stringify({ password: formData.get('password') }),
-        headers: { 'Content-Type': 'application/json' },
+        method: "post",
+        credentials: "include",
+        body: JSON.stringify({ password: formData.get("password") }),
+        headers: { "Content-Type": "application/json" },
       });
 
       const { message } = await res.json();
@@ -46,7 +45,7 @@ export const LoginComponent = ({
         setBusy(false);
       }
     } catch (e) {
-      setError('An error has occured.');
+      setError("An error has occured.");
       setBusy(false);
     }
 
@@ -54,126 +53,134 @@ export const LoginComponent = ({
   };
 
   return (
-    <div className="w-full min-h-screen flex flex-col items-center justify-center bg-gray-100"
-    >
-      <div className="flex flex-col items-center max-w-[32em]">
-        <div className="p-10 bg-white">
-          <a className="block w-[203px] mt-[-60px]">
-            <Image
-              src="/undp-logo.svg"
-              height={49.27}
-              width={100}
-              layout="responsive"
-              alt="UNDP Logo"
-            />
-          </a>
+    <>
+      <style>{`body {background: #f1f5f9;}`}</style>
+      <div className="lg:h-screen flex flex-col lg:flex-row divide-y lg:divide-y-0 divide-x">
+        <div className="order-0 lg:order-1 flex-1 flex flex-col items-center justify-center px-10">
+          <div className="w-full lg:max-w-sm" id="password-form">
+            <form
+              data-testid="form"
+              onSubmit={onSubmit}
+              className="my-8 w-full flex flex-col"
+            >
+              <input
+                name="password"
+                type="password"
+                id="password"
+                placeholder="Enter password"
+                required
+                className={`border py-2 px-3 ${error ? "border-red-500" : ""}`}
+              />
+              {!!error && (
+                <div className="text-red-500" data-testid="error">
+                  {error}
+                </div>
+              )}
 
-          <h1 className="font-semibold text-2xl py-3">
-            Digital Development Compass
-          </h1>
+              <button
+                type="submit"
+                disabled={isBusy}
+                className="font-semibold w-full text-sm py-3 uppercase tracking-wide mt-3 bg-gray-900 text-white"
+              >
+                {isBusy ? "Logging in..." : "Login"}
+              </button>
+            </form>
+          </div>
+        </div>
+        <div className="lg:w-1/2 flex-shrink-0 bg-white divide-y">
+          <div className="p-4 lg:p-8">
+            <div className="block w-16 mx-auto">
+              <Image src={UNDPLogo} alt="UNDP Logo" />
+            </div>
 
-          <p>
-            The Digital Development Compass is a new tool that aggregates publicly available data on countries’ digital development in one place. Now in its beta phase, it uses UNDP's whole-of-society approach and country experience to assess countries' efforts in inclusive digital transformation. It also identifies gaps, and recommends improvements to make this transformation easier and faster. Please subscribe to receive updates or reach out to <a className="underline" href="mailto:digital@undp.org">digital@undp.org</a> with any inquires.
-          </p>
+            <h1 className="font-medium text-2xl text-center mt-2">
+              Digital Development Compass
+            </h1>
 
+            <p className="text-gray-600 text-left mt-4">
+              The Digital Development Compass is a new tool that aggregates
+              publicly available data on countries’ digital development in one
+              place. Now in its beta phase, it uses UNDP's whole-of-society
+              approach and country experience to assess countries' efforts in
+              inclusive digital transformation. It also identifies gaps, and
+              recommends improvements to make this transformation easier and
+              faster. Please subscribe to receive updates or reach out to{" "}
+              <a className="underline" href="mailto:digital@undp.org">
+                digital@undp.org
+              </a>{" "}
+              with any inquires.
+            </p>
+          </div>
 
-          <div id="mc_embed_signup">
-            <form action="https://undp.us7.list-manage.com/subscribe/post?u=148ee4035f554a53ad2545a67&amp;id=232e454b96" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" className="validate" target="_blank" noValidate>
+          <div className="p-4 lg:p-8" id="mc_embed_signup">
+            <form
+              action="https://undp.us7.list-manage.com/subscribe/post?u=148ee4035f554a53ad2545a67&amp;id=232e454b96"
+              method="post"
+              id="mc-embedded-subscribe-form"
+              name="mc-embedded-subscribe-form"
+              className="validate"
+              target="_blank"
+              noValidate
+            >
               <div id="mc_embed_signup_scroll" className="space-y-2 mt-6">
-                <h2 className="font-semibold text-2xl">Join Us For Updates &amp; A Launch Event Invitation</h2>
+                <h2 className="font-semibold text-2xl">
+                  Join Us For Updates &amp; A Launch Event Invitation
+                </h2>
                 <div className="mc-field-group">
-                  <label htmlFor="mce-EMAIL">Email Address<span className="text-red-500">*</span>
+                  <label htmlFor="mce-EMAIL">
+                    Email Address<span className="text-red-500">*</span>
                   </label>
-                  <input type="email" name="EMAIL" className={`border py-2 px-3 w-full`} id="mce-EMAIL" />
+                  <input
+                    type="email"
+                    name="EMAIL"
+                    className={`border py-2 px-3 w-full`}
+                    id="mce-EMAIL"
+                  />
                 </div>
                 <div className="mc-field-group">
                   <label htmlFor="mce-COUNTRY">Country </label>
-                  <input type="text" name="COUNTRY" className={`border py-2 px-3 w-full`} id="mce-COUNTRY" />
+                  <input
+                    type="text"
+                    name="COUNTRY"
+                    className={`border py-2 px-3 w-full`}
+                    id="mce-COUNTRY"
+                  />
                 </div>
-                <div hidden><input type="hidden" name="tags" value="6730541" /></div>
-                <div id="mce-responses" className="clear" >
-                  <div className="response hidden" id="mce-error-response"></div>
-                  <div className="response hidden" id="mce-success-response"></div>
+                <div hidden>
+                  <input type="hidden" name="tags" value="6730541" />
+                </div>
+                <div id="mce-responses" className="clear">
+                  <div
+                    className="response hidden"
+                    id="mce-error-response"
+                  ></div>
+                  <div
+                    className="response hidden"
+                    id="mce-success-response"
+                  ></div>
                 </div>
                 {/* <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups--> */}
-                <div className="absolute left-[-5000px]" aria-hidden="true"><input type="text" name="b_148ee4035f554a53ad2545a67_232e454b96" tabIndex={-1} /></div>
-                <div className="clear"><input className="bg-[#0063AC] hover:bg-blue-700 text-white font-bold mt-3 py-3 px-4 rounded-full w-full" type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" /></div>
+                <div className="absolute left-[-5000px]" aria-hidden="true">
+                  <input
+                    type="text"
+                    name="b_148ee4035f554a53ad2545a67_232e454b96"
+                    tabIndex={-1}
+                  />
+                </div>
+                <div className="clear">
+                  <input
+                    className="bg-brand-blue-dark hover:bg-brand-blue text-white mt-3 font-semibold w-full text-sm py-3 uppercase tracking-wide"
+                    type="submit"
+                    value="Subscribe"
+                    name="subscribe"
+                    id="mc-embedded-subscribe"
+                  />
+                </div>
               </div>
             </form>
           </div>
-
         </div>
-
-
-        <div className="px-10 w-full"
-          id="password-form">
-          <form
-            data-testid="form"
-            onSubmit={onSubmit}
-            className="my-8 w-full flex flex-col"
-          >
-            <input
-              name="password"
-              type="password"
-              id="password"
-              placeholder="Enter password..."
-              required
-              className={`border py-2 px-3 ${error ? "border-red-500" : ""}`}
-            />
-            {!!error && (
-              <div className="text-red-500" data-testid="error">
-                {error}
-              </div>
-            )}
-
-            <button
-              type="submit"
-              disabled={isBusy}
-              className="bg-[#0A0A0A] hover:bg-blue-700 text-white font-bold mt-3 py-3 px-4 rounded-full"
-            >
-              {isBusy ? 'Logging in...' : 'Login'}
-            </button>
-          </form>
-        </div>
-
-
-        {/* <div
-          className="mt-10"
-          dangerouslySetInnerHTML={{
-            __html: `<!-- Begin Mailchimp Signup Form -->
-<link href="//cdn-images.mailchimp.com/embedcode/classic-10_7.css" rel="stylesheet" type="text/css">
-<style type="text/css">
-	#mc_embed_signup{width:100%;}
-</style>
-<div id="mc_embed_signup">
-<form action="https://undp.us7.list-manage.com/subscribe/post?u=148ee4035f554a53ad2545a67&amp;id=232e454b96" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" class="validate" target="_blank" novalidate>
-    <div id="mc_embed_signup_scroll">
-	<h2>Join Us For Updates &amp; Launch Event Invitation</h2>
-<div class="indicates-required"><span class="asterisk">*</span> indicates required</div>
-<div class="mc-field-group">
-	<label for="mce-EMAIL">Email Address  <span class="asterisk">*</span>
-</label>
-	<input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL">
-</div>
-<div class="mc-field-group">
-	<label for="mce-COUNTRY">Country </label>
-	<input type="text" value="" name="COUNTRY" class="" id="mce-COUNTRY">
-</div>
-<div hidden="true"><input type="hidden" name="tags" value="6730541"></div>
-	<div id="mce-responses" class="clear">
-		<div class="response" id="mce-error-response" style="display:none"></div>
-		<div class="response" id="mce-success-response" style="display:none"></div>
-	</div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-    <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_148ee4035f554a53ad2545a67_232e454b96" tabindex="-1" value=""></div>
-    <div class="clear"><input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="button"></div>
-    </div>
-</form>
-</div>
-<script type='text/javascript' src='//s3.amazonaws.com/downloads.mailchimp.com/js/mc-validate.js'></script><script type='text/javascript'>(function($) {window.fnames = new Array(); window.ftypes = new Array();fnames[0]='EMAIL';ftypes[0]='email';fnames[1]='FNAME';ftypes[1]='text';fnames[2]='LNAME';ftypes[2]='text';fnames[3]='ADDRESS';ftypes[3]='address';fnames[4]='PHONE';ftypes[4]='phone';fnames[5]='BIRTHDAY';ftypes[5]='birthday';fnames[6]='TITLE';ftypes[6]='text';fnames[7]='UNIT';ftypes[7]='text';fnames[8]='COUNTRY';ftypes[8]='text';}(jQuery));var $mcj = jQuery.noConflict(true);</script>
-<!--End mc_embed_signup-->` }} />
-
-      </div> */}
       </div>
-    </div>
+    </>
   );
 };


### PR DESCRIPTION
@mbelinsky @Wattenberger What do you all think about these design tweaks to the login page? My goals here were to:
- Fix the cutoff logo issue that was reported
- Unify the look & feel of the header styles between this page and the navbar from the logged in experience
- Buy us some more screen real estate for the login area. I know this page is for non-authed users, but I wonder if we have a chance on this page to "tease" some of the data points and/or interactive components that are featured within the UI? Could we embed a globe here? Some of the `StageGauge` components? Please ignore if this is totally irrelevant :) 

**Desktop**
<img width="1294" alt="Screen Shot 2022-08-29 at 12 19 02 PM" src="https://user-images.githubusercontent.com/5148596/187189900-5a721730-4dd6-496c-98f4-99017a2ed488.png">

**Mobile**
<img width="529" alt="Screen Shot 2022-08-29 at 12 20 04 PM" src="https://user-images.githubusercontent.com/5148596/187189977-da7d987f-e860-42a2-80ef-8a7eb86e198d.png">

**Example with Globe**
<img width="1440" alt="Screen Shot 2022-08-29 at 2 45 02 PM" src="https://user-images.githubusercontent.com/5148596/187215723-c8502411-12b1-4bd4-83e7-173ade01937f.png">
